### PR TITLE
Update 3gpp_type.go

### DIFF
--- a/3gpp_type.go
+++ b/3gpp_type.go
@@ -12,6 +12,6 @@ func (d *Dnn) MarshalBinary() (data []byte, err error) {
 
 func (d *Dnn) UnmarshalBinary(data []byte) error {
 
-	(*d) = data[1:]
+	(*d) = data[:]
 	return nil
 }


### PR DESCRIPTION
UnmarshalBinary method skips the first byte

func (d *Dnn) UnmarshalBinary(data []byte) error {

(*d) = data[1:]   <-- This skips the first byte
return nil
}